### PR TITLE
Fix for MicroService @UiThread error introduced in Flutter 1.7

### DIFF
--- a/android/src/main/java/io/jojodev/flutter/liquidcore/handler/MicroServiceHandler.java
+++ b/android/src/main/java/io/jojodev/flutter/liquidcore/handler/MicroServiceHandler.java
@@ -150,6 +150,17 @@ public class MicroServiceHandler implements MethodChannel.MethodCallHandler {
         return result;
     }
 
+    private void invokeMicroServiceMethod(final String method, final Object arguments) {
+        if (microServiceMethodChannel != null) {
+            registrar.activity().runOnUiThread(new Runnable() {
+                @Override
+                public void run() {
+                    microServiceMethodChannel.invokeMethod(method, arguments);
+                }
+            });
+        }
+    }
+
     private class MicroServiceListener implements IMicroServiceListener {
 
         private String serviceId;
@@ -160,23 +171,17 @@ public class MicroServiceHandler implements MethodChannel.MethodCallHandler {
 
         @Override
         public void onStart(MicroService service) {
-            if (microServiceMethodChannel != null) {
-                microServiceMethodChannel.invokeMethod("listener.onStart", buildArguments(serviceId, null));
-            }
+            invokeMicroServiceMethod("listener.onStart", buildArguments(serviceId, null));
         }
 
         @Override
         public void onError(MicroService service, Exception e) {
-            if (microServiceMethodChannel != null) {
-                microServiceMethodChannel.invokeMethod("listener.onError", buildArguments(serviceId, e));
-            }
+            invokeMicroServiceMethod("listener.onError", buildArguments(serviceId, e));
         }
 
         @Override
         public void onExit(MicroService service, Integer exitCode) {
-            if (microServiceMethodChannel != null) {
-                microServiceMethodChannel.invokeMethod("listener.onExit", buildArguments(serviceId, exitCode));
-            }
+            invokeMicroServiceMethod("listener.onExit", buildArguments(serviceId, exitCode));
             synchronized (microServicesMapLocker) {
                 // Remove the service instance.
                 microServices.remove(serviceId);
@@ -203,7 +208,7 @@ public class MicroServiceHandler implements MethodChannel.MethodCallHandler {
                 Map<String, Object> map = new HashMap<>();
                 map.put("event", event);
                 map.put("payload", payloadObject);
-                microServiceMethodChannel.invokeMethod("listener.onEvent", buildArguments(serviceId, map));
+                invokeMicroServiceMethod("listener.onEvent", buildArguments(serviceId, map));
             }
         }
     }


### PR DESCRIPTION
This is a fix for issue https://github.com/j0j00/flutter_liquidcore/issues/5 and possibly also https://github.com/j0j00/flutter_liquidcore/issues/1.

Google introduced a new error with commit https://github.com/flutter/engine/commit/2c9e37c34e79475bbde7c8163eb5e56cdb9662a that causes plugins to throw if they are not run on the main thread when marked with `@UiThread`, which seems to be the problem with #5.

The only proposed fix (see https://github.com/flutter/flutter/issues/34993 thread in particular) for this issue that I could find is to ensure that the method runs on the main thread as requested. This pull request implements said fix.

Even though the `invokeMethod` calls are now always made on the main thread, the Node.js VM is still run on a separate thread and won't lock up the UI while JavaScript code is being evaluated.